### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The first pass involves mapping the input object according to any custom encodin
 
 The second pass performs the actual encoding of the input to a JSON string. This is done in the Rust NIF.
 
-If custom encoding defintions are not required, the first pass can be disabled entirely by passing `lean: true` in the encode opts. When operating in this mode, structs will always be encoded as if they were maps regardless of custom encoder implementations.
+If custom encoding definitions are not required, the first pass can be disabled entirely by passing `lean: true` in the encode opts. When operating in this mode, structs will always be encoded as if they were maps regardless of custom encoder implementations.
 
 ## Performance
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,4 +7,4 @@ From: https://hexdocs.pm/rustler_precompiled/precompilation_guide.html#recommend
 - `git push --tags`
 - Wait for the associated GitHub actions to finish
 - Run `mix rustler_precompiled.download Jsonrs --all`
-- Release the packge to hex.pm `mix hex.publish` (making sure to include the correct files (**untested!**)
+- Release the package to hex.pm `mix hex.publish` (making sure to include the correct files (**untested!**)


### PR DESCRIPTION
Found via `codespell -S deps -L crate,ser`