### PR TITLE
Gzip encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ It is easy to see that Jsonrs dramatically outperforms Poison and Jason, while J
 `Jsonrs.encode/2` takes an Elixir term and a keyword list of options and turns the input term into a JSON string with behavior defined by the options. Valid options are:
 * `lean`: disables the first encoder pass (default `false`)
 * `pretty`: turns on pretty printing when `true` or a non-negative-integer specifying indentation size (default `false`)
+* `compress`: turns on streaming compression when passed in.
+  * Currently you can pass in `true`, or `:gzip` to get default level gzip compression
+  * You can also pass `{:gzip, 0..9}` to get a specific level of gzip compression
+  * Other compression forms may be accepted in the future
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ It is easy to see that Jsonrs dramatically outperforms Poison and Jason, while J
 * `lean`: disables the first encoder pass (default `false`)
 * `pretty`: turns on pretty printing when `true` or a non-negative-integer specifying indentation size (default `false`)
 * `compress`: turns on streaming compression when passed in.
-  * Currently you can pass in `true`, or `:gzip` to get default level gzip compression
+  * Currently you can pass `:gzip` to get default level gzip compression
   * You can also pass `{:gzip, 0..9}` to get a specific level of gzip compression
   * Other compression forms may be accepted in the future
 

--- a/lib/jsonrs.ex
+++ b/lib/jsonrs.ex
@@ -114,6 +114,8 @@ defmodule Jsonrs do
   @spec encode_to_iodata!(term, keyword) :: String.t()
   def encode_to_iodata!(input, opts \\ []), do: encode!(input, opts)
 
+  defp validate_compression(nil), do: {:none, nil}
+  defp validate_compression(false), do: {:none, nil}
   defp validate_compression(atom) when is_atom(atom), do: {atom, nil}
   defp validate_compression(other), do: other
 end

--- a/native/jsonrs/Cargo.lock
+++ b/native/jsonrs/Cargo.lock
@@ -3,12 +3,59 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "libz-ng-sys",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -27,6 +74,7 @@ checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 name = "jsonrs"
 version = "0.2.1"
 dependencies = [
+ "flate2",
  "lazy_static",
  "rustler",
  "serde",
@@ -42,10 +90,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "libc"
+version = "0.2.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4399ae96a9966bf581e726de86969f803a81b7ce795fcd5480e640589457e0f2"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/native/jsonrs/Cargo.lock
+++ b/native/jsonrs/Cargo.lock
@@ -18,25 +18,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cmake"
-version = "0.1.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "crc32fast"
@@ -54,7 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -88,22 +72,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "libc"
-version = "0.2.140"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
-
-[[package]]
-name = "libz-ng-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4399ae96a9966bf581e726de86969f803a81b7ce795fcd5480e640589457e0f2"
-dependencies = [
- "cmake",
- "libc",
-]
 
 [[package]]
 name = "memchr"

--- a/native/jsonrs/Cargo.toml
+++ b/native/jsonrs/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
+flate2 = { version = "1.0", features = ["zlib-ng"] }
 rustler = "0.27.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/native/jsonrs/Cargo.toml
+++ b/native/jsonrs/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-flate2 = { version = "1.0", features = ["zlib-ng"] }
+flate2 = { version = "1.0" }
 rustler = "0.27.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/native/jsonrs/src/compression.rs
+++ b/native/jsonrs/src/compression.rs
@@ -1,0 +1,34 @@
+use rustler::NifUnitEnum;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use std::io::{BufWriter, Write, Error};
+
+#[derive(NifUnitEnum)]
+pub enum Algs {
+  None,
+  Gzip,
+}
+
+pub trait BufWrapper: Write {
+  fn get_buf(&mut self) -> Result<Vec<u8>, Error>;
+}
+
+impl BufWrapper for Vec<u8> {
+  fn get_buf(&mut self) -> Result<Vec<u8>, Error> { Ok(self.to_vec()) }
+}
+
+impl BufWrapper for BufWriter<GzEncoder<Vec<u8>>> {
+  fn get_buf(&mut self) -> Result<Vec<u8>, Error> {
+    self.flush()?;
+    self.get_mut().try_finish()?;
+    Ok(self.get_ref().get_ref().to_vec())
+  }
+}
+
+pub fn get_writer(opts: Option<(Algs, Option<u32>)>) -> Box<dyn BufWrapper> {
+  match opts {
+    Some((Algs::Gzip, None)) => Box::new(BufWriter::with_capacity(10_240, GzEncoder::new(Vec::new(), Compression::default()))),
+    Some((Algs::Gzip, Some(lv))) => Box::new(BufWriter::with_capacity(10_240, GzEncoder::new(Vec::new(), Compression::new(lv)))),
+    _ => Box::new(Vec::<u8>::new()),
+  }
+}

--- a/native/jsonrs/src/lib.rs
+++ b/native/jsonrs/src/lib.rs
@@ -4,8 +4,8 @@ mod compression;
 rustler::init!("Elixir.Jsonrs", [encode, decode]);
 
 #[rustler::nif(name = "nif_encode", schedule = "DirtyCpu")]
-fn encode(term: Term, indent_size: Option<u32>, compression: Option<(compression::Algs, Option<u32>)>) -> Result<String, Error> {
-  let mut buf = compression::get_writer(compression);
+fn encode(term: Term, indent_size: Option<u32>, comp_opts: Option<(compression::Algs, Option<u32>)>) -> Result<String, Error> {
+  let mut buf = compression::get_writer(comp_opts);
   let des = serde_rustler::Deserializer::from(term);
   match indent_size {
     None => serde_transcode::transcode(des, &mut serde_json::Serializer::new(&mut buf)),

--- a/test/jsonrs_test.exs
+++ b/test/jsonrs_test.exs
@@ -29,13 +29,25 @@ defmodule JsonrsTest do
       assert %{"hour" => _, "minute" => _, "second" => _} = Jsonrs.encode!(~T[12:00:00], lean: true) |> Jsonrs.decode!()
     end
 
-    test "with compression: :gzip" do
-      assert zipped = Jsonrs.encode!(%{"foo" => 5}, compression: :gzip)
+    test "with compress: true" do
+      assert zipped = Jsonrs.encode!(%{"foo" => 5}, compress: true)
       assert :zlib.gunzip(zipped) == ~s({"foo":5})
     end
 
-    test "with compression and pretty" do
-      assert zipped = Jsonrs.encode!([1], compression: :gzip, pretty: 2)
+    test "with compress: :gzip" do
+      assert zipped = Jsonrs.encode!(%{"foo" => 5}, compress: :gzip)
+      assert :zlib.gunzip(zipped) == ~s({"foo":5})
+    end
+
+    test "with compress: {:gzip, level}" do
+      for level <- 0..9 do
+        assert zipped = Jsonrs.encode!(%{"Leslie" => "Pawnee"}, compress: {:gzip, level})
+        assert :zlib.gunzip(zipped) == ~s({"Leslie":"Pawnee"})
+      end
+    end
+
+    test "with compress and pretty" do
+      assert zipped = Jsonrs.encode!([1], compress: :gzip, pretty: 2)
       assert :zlib.gunzip(zipped) == "[\n  1\n]"
     end
   end

--- a/test/jsonrs_test.exs
+++ b/test/jsonrs_test.exs
@@ -46,13 +46,18 @@ defmodule JsonrsTest do
       assert :zlib.gunzip(zipped) == "[\n  1\n]"
     end
 
+    test "with compress: false/nil" do
+      assert Jsonrs.encode!(%{ron: "swanson"}, compress: false) == ~S({"ron":"swanson"})
+      assert Jsonrs.encode!(%{ron: "swanson"}, compress: nil) == ~S({"ron":"swanson"})
+    end
+
     test "with invalid compress options" do
       assert_raise ArgumentError, "argument error", fn ->
         Jsonrs.encode!(%{foo: "bar"}, compress: :zlib)
       end
 
       assert_raise ArgumentError, "argument error", fn ->
-        Jsonrs.encode!(%{foo: "bar"}, compress: false)
+        Jsonrs.encode!(%{foo: "bar"}, compress: "Wat?!?!")
       end
 
       assert_raise ArgumentError, "argument error", fn ->

--- a/test/jsonrs_test.exs
+++ b/test/jsonrs_test.exs
@@ -28,6 +28,16 @@ defmodule JsonrsTest do
       assert "12:00:00" == Jsonrs.encode!(~T[12:00:00]) |> Jsonrs.decode!()
       assert %{"hour" => _, "minute" => _, "second" => _} = Jsonrs.encode!(~T[12:00:00], lean: true) |> Jsonrs.decode!()
     end
+
+    test "with compression: :gzip" do
+      assert zipped = Jsonrs.encode!(%{"foo" => 5}, compression: :gzip)
+      assert :zlib.gunzip(zipped) == ~s({"foo":5})
+    end
+
+    test "with compression and pretty" do
+      assert zipped = Jsonrs.encode!([1], compression: :gzip, pretty: 2)
+      assert :zlib.gunzip(zipped) == "[\n  1\n]"
+    end
   end
 
   describe "decodes" do

--- a/test/jsonrs_test.exs
+++ b/test/jsonrs_test.exs
@@ -29,11 +29,6 @@ defmodule JsonrsTest do
       assert %{"hour" => _, "minute" => _, "second" => _} = Jsonrs.encode!(~T[12:00:00], lean: true) |> Jsonrs.decode!()
     end
 
-    test "with compress: true" do
-      assert zipped = Jsonrs.encode!(%{"foo" => 5}, compress: true)
-      assert :zlib.gunzip(zipped) == ~s({"foo":5})
-    end
-
     test "with compress: :gzip" do
       assert zipped = Jsonrs.encode!(%{"foo" => 5}, compress: :gzip)
       assert :zlib.gunzip(zipped) == ~s({"foo":5})
@@ -49,6 +44,20 @@ defmodule JsonrsTest do
     test "with compress and pretty" do
       assert zipped = Jsonrs.encode!([1], compress: :gzip, pretty: 2)
       assert :zlib.gunzip(zipped) == "[\n  1\n]"
+    end
+
+    test "with invalid compress options" do
+      assert_raise ArgumentError, "argument error", fn ->
+        Jsonrs.encode!(%{foo: "bar"}, compress: :zlib)
+      end
+
+      assert_raise ArgumentError, "argument error", fn ->
+        Jsonrs.encode!(%{foo: "bar"}, compress: false)
+      end
+
+      assert_raise ArgumentError, "argument error", fn ->
+        Jsonrs.encode!(%{foo: "bar"}, compress: {:gzip, "foo"})
+      end
     end
   end
 


### PR DESCRIPTION
I got a rough start on the idea of #14 

Initially I am trying out having a separate `encode_gzip!` function which does not support options for pretty printing. Those two features don't seem to make much sense together. Maybe this should be an option passed to the `encode` function instead?

In this first implementation, the gzip happens as a single big operation after the encoding is complete. My initial idea was to do a stream gzip, but I haven't found a good way to make that work yet. In benchmarks for my work project, this version of the library is about 1.8x faster and uses about 60% as much memory as using `:jiffy.encode` + `:zlib.gzip`. It's also a noticeably faster than using `Jsonrs.encode!` + `:zlib.gzip`. Probably because it's less expensive to pass the gzipped string back into the beam rather than passing the entire json string and then having the beam be responsible for garbage collection etc.

I still want to try out the idea of a streaming gzip, maybe by passing a buffered `Write` into the `serde-transpose` operation rather than a bare `Vec::new()`? I'm not sure if serde supports that. I'm still fumbling through rust with my limited knowledge of how the read the docs etc. But I wanted to open the PR now in case it sparks any ideas.