### PR TITLE
Use new rustler API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Errors returned from `encode/2` are now descriptive strings instead of a generic atom. Instead of `{:error, :encode_error}`, you may now see something like `{:error, "Expected to deserialize a UTF-8 stringable term"}`. This is technically a breaking change.
 
 ## [0.2.1] - 2022-11-06
 ### Added

--- a/lib/jsonrs.ex
+++ b/lib/jsonrs.ex
@@ -29,7 +29,7 @@ defmodule Jsonrs do
       iex> Jsonrs.encode("\\xFF")
       {:error, :encode_error}
   """
-  @spec encode(term, keyword) :: {:ok, String.t()} | {:error, :encode_error}
+  @spec encode(term, keyword) :: {:ok, String.t()} | {:error, String.t()}
   def encode(input, opts \\ []) do
     {:ok, encode!(input, opts)}
   rescue

--- a/native/jsonrs/Cargo.lock
+++ b/native/jsonrs/Cargo.lock
@@ -31,7 +31,6 @@ dependencies = [
  "rustler",
  "serde",
  "serde-transcode",
- "serde_bytes",
  "serde_json",
  "serde_rustler",
 ]
@@ -142,15 +141,6 @@ name = "serde-transcode"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97528f0dfcf8ce2d51d995cb513a103b9cd301dc3f387a9cae5ef974381d4e1c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
 dependencies = [
  "serde",
 ]

--- a/native/jsonrs/Cargo.toml
+++ b/native/jsonrs/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["dylib"]
 [dependencies]
 rustler = "0.25.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_bytes = "0.11"
 serde_json = "1.0"
 serde_rustler = { git = "https://github.com/benhaney/serde_rustler", tag = "v0.0.5" }
 serde-transcode = "1.1"

--- a/native/jsonrs/src/lib.rs
+++ b/native/jsonrs/src/lib.rs
@@ -1,46 +1,27 @@
-use rustler::{Env, NifResult, Term};
-use serde_rustler::{from_term, to_term};
+use rustler::{Env, Error, Term};
 
-rustler::rustler_export_nifs! {
-  "Elixir.Jsonrs",
-  [
-    ("nif_encode!", 1, encode, rustler::schedule::SchedulerFlags::DirtyCpu),
-    ("nif_decode!", 1, decode, rustler::schedule::SchedulerFlags::DirtyCpu),
-    ("nif_encode_pretty!", 2, encode_pretty, rustler::schedule::SchedulerFlags::DirtyCpu),
-  ],
-  None
-}
+rustler::init!("Elixir.Jsonrs", [encode, decode]);
 
-fn encode<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-  // Buffer for serde_json's serializer to write to
+#[rustler::nif(name = "nif_encode", schedule = "DirtyCpu")]
+fn encode(term: Term, indent_size: Option<u32>) -> Result<String, Error> {
   let mut buf = Vec::new();
-  serde_transcode::transcode(
-    serde_rustler::Deserializer::from(args[0]),
-    &mut serde_json::Serializer::new(&mut buf)
-  ).or(Err(rustler::Error::RaiseAtom("encode_error")))?;
-  // Turn the json buffer back into an Elixir binary (string) term
-  to_term(env, serde_bytes::Bytes::new(&buf)).map_err(|e| e.into())
+  let des = serde_rustler::Deserializer::from(term);
+  match indent_size {
+    None => serde_transcode::transcode(des, &mut serde_json::Serializer::new(&mut buf)),
+    Some(inds) => {
+      let indent = std::iter::repeat(" ").take(inds as usize).collect::<String>();
+      let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
+      serde_transcode::transcode(des, &mut serde_json::Serializer::with_formatter(&mut buf, formatter))
+    }
+  }.or(Err(Error::RaiseAtom("encode_error")))?;
+
+  unsafe { Ok(String::from_utf8_unchecked(buf)) }
 }
 
-// Takes a term and an indentation size
-fn encode_pretty<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-  // Buffer for serde_json's serializer to write to
-  let mut buf = Vec::new();
-  let indent_size: u32 = from_term(args[1])?;
-  let indent = std::iter::repeat(" ").take(indent_size as usize).collect::<String>();
-  let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
+#[rustler::nif(name = "nif_decode", schedule = "DirtyCpu")]
+fn decode<'a>(env: Env<'a>, string: String) -> Result<Term<'a>, Error> {
   serde_transcode::transcode(
-    serde_rustler::Deserializer::from(args[0]),
-    &mut serde_json::Serializer::with_formatter(&mut buf, formatter)
-  ).or(Err(rustler::Error::RaiseAtom("encode_error")))?;
-  // Turn the json buffer back into an Elixir binary (string) term
-  to_term(env, serde_bytes::Bytes::new(&buf)).map_err(|e| e.into())
-}
-
-fn decode<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-  // Transcode the Json bytes from an Elixir string term right back into a deserialized Elixir term
-  serde_transcode::transcode(
-    &mut serde_json::Deserializer::from_slice(from_term(args[0])?),
+    &mut serde_json::Deserializer::from_slice(string.as_bytes()),
     serde_rustler::Serializer::from(env)
   ).map_err(|e| e.into())
 }

--- a/native/jsonrs/src/lib.rs
+++ b/native/jsonrs/src/lib.rs
@@ -13,7 +13,7 @@ fn encode(term: Term, indent_size: Option<u32>) -> Result<String, Error> {
       let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
       serde_transcode::transcode(des, &mut serde_json::Serializer::with_formatter(&mut buf, formatter))
     }
-  }.or(Err(Error::RaiseAtom("encode_error")))?;
+  }.map_err(|e| Error::RaiseTerm(Box::new(format!("{}", e))))?;
 
   unsafe { Ok(String::from_utf8_unchecked(buf)) }
 }


### PR DESCRIPTION
Finally update to the new Rustler API introduced in Rustler 0.22 and stop using the deprecated API. Also merges the `encode` and `encode_pretty` nif functions.

Need to check for performance regressions before merging.